### PR TITLE
Removing always disabling the gradle-daemon per https://docs.gradle.o…

### DIFF
--- a/docs/extending-with-custom-configurable-dsl-components.md
+++ b/docs/extending-with-custom-configurable-dsl-components.md
@@ -72,7 +72,7 @@ data class GradleBuildDsl(
     ...
     fun DslContext<Step>.gradleCommand(command: String, additionalBuildArgs: Var.Literal.Str) =
             withEnv(mapOf("GRADLE_USER_HOME" to "${"WORKSPACE".environmentVar()}/.gradle-home-tmp")) { artifactoryAuthenticated {
-                sh(("./gradlew --no-daemon --stacktrace --build-cache " +
+                sh(("./gradlew  --stacktrace --build-cache " +
                         (gradleCredentials?.let { "-D$gradleUserProperty=\\\"\\\${${it.usernameVariable.value}}\\\" -D$gradlePasswordProperty=\\\"\\\${${it.passwordVariable.value}}\\\" " } ?: "") +
                         "$additionalBuildArgs $command").strDouble())
             } }

--- a/docs/extending-with-custom-configurable-dsl-components.md
+++ b/docs/extending-with-custom-configurable-dsl-components.md
@@ -71,8 +71,11 @@ data class GradleBuildDsl(
 ) {
     ...
     fun DslContext<Step>.gradleCommand(command: String, additionalBuildArgs: Var.Literal.Str) =
-            withEnv(mapOf("GRADLE_USER_HOME" to "${"WORKSPACE".environmentVar()}/.gradle-home-tmp")) { artifactoryAuthenticated {
-                sh(("./gradlew  --stacktrace --build-cache " +
+            withEnv(
+                mapOf("GRADLE_USER_HOME" to "${"WORKSPACE".environmentVar()}/.gradle-home-tmp",
+                "JENKINS_NODE_COOKIE" to "dontKillMe")
+            ) { artifactoryAuthenticated {
+                sh(("./gradlew --stacktrace --build-cache " +
                         (gradleCredentials?.let { "-D$gradleUserProperty=\\\"\\\${${it.usernameVariable.value}}\\\" -D$gradlePasswordProperty=\\\"\\\${${it.passwordVariable.value}}\\\" " } ?: "") +
                         "$additionalBuildArgs $command").strDouble())
             } }

--- a/dsl/src/main/kotlin/com/code42/jenkins/pipelinekt/dsl/step/custom/GradleBuildDsl.kt
+++ b/dsl/src/main/kotlin/com/code42/jenkins/pipelinekt/dsl/step/custom/GradleBuildDsl.kt
@@ -55,7 +55,10 @@ data class GradleBuildDsl(
             } }
 
     fun DslContext<Step>.gradleCommandBat(command: String, additionalBuildArgs: Var.Literal.Str) =
-            withEnv(mapOf("GRADLE_USER_HOME" to "${"WORKSPACE".environmentVar()}/.gradle-home-tmp")) { artifactoryAuthenticated {
+            withEnv(
+                    mapOf("GRADLE_USER_HOME" to "${"WORKSPACE".environmentVar()}/.gradle-home-tmp",
+                    "JENKINS_NODE_COOKIE" to "dontKillMe")
+            ) { artifactoryAuthenticated {
                 bat(("call gradlew.bat --stacktrace --build-cache " +
                         (gradleCredentials?.let { "-D$gradleUserProperty=%${it.usernameVariable.value}% -D$gradlePasswordProperty=%${it.passwordVariable.value}% " } ?: "") +
                         "$additionalBuildArgs $command").strDouble())

--- a/dsl/src/main/kotlin/com/code42/jenkins/pipelinekt/dsl/step/custom/GradleBuildDsl.kt
+++ b/dsl/src/main/kotlin/com/code42/jenkins/pipelinekt/dsl/step/custom/GradleBuildDsl.kt
@@ -45,7 +45,10 @@ data class GradleBuildDsl(
             this.gradleCommandBat(command, additionalBuildArgs.strDouble())
 
     fun DslContext<Step>.gradleCommandSh(command: String, additionalBuildArgs: Var.Literal.Str) =
-            withEnv(mapOf("GRADLE_USER_HOME" to "${"WORKSPACE".environmentVar()}/.gradle-home-tmp")) { artifactoryAuthenticated {
+            withEnv(
+                mapOf("GRADLE_USER_HOME" to "${"WORKSPACE".environmentVar()}/.gradle-home-tmp",
+                "JENKINS_NODE_COOKIE" to "dontKillMe")
+            ) { artifactoryAuthenticated {
                 sh(("./gradlew --stacktrace --build-cache " +
                         (gradleCredentials?.let { "-D$gradleUserProperty=\\\"\\\${${it.usernameVariable.value}}\\\" -D$gradlePasswordProperty=\\\"\\\${${it.passwordVariable.value}}\\\" " } ?: "") +
                         "$additionalBuildArgs $command").strDouble())

--- a/dsl/src/main/kotlin/com/code42/jenkins/pipelinekt/dsl/step/custom/GradleBuildDsl.kt
+++ b/dsl/src/main/kotlin/com/code42/jenkins/pipelinekt/dsl/step/custom/GradleBuildDsl.kt
@@ -46,14 +46,14 @@ data class GradleBuildDsl(
 
     fun DslContext<Step>.gradleCommandSh(command: String, additionalBuildArgs: Var.Literal.Str) =
             withEnv(mapOf("GRADLE_USER_HOME" to "${"WORKSPACE".environmentVar()}/.gradle-home-tmp")) { artifactoryAuthenticated {
-                sh(("./gradlew --no-daemon --stacktrace --build-cache " +
+                sh(("./gradlew --stacktrace --build-cache " +
                         (gradleCredentials?.let { "-D$gradleUserProperty=\\\"\\\${${it.usernameVariable.value}}\\\" -D$gradlePasswordProperty=\\\"\\\${${it.passwordVariable.value}}\\\" " } ?: "") +
                         "$additionalBuildArgs $command").strDouble())
             } }
 
     fun DslContext<Step>.gradleCommandBat(command: String, additionalBuildArgs: Var.Literal.Str) =
             withEnv(mapOf("GRADLE_USER_HOME" to "${"WORKSPACE".environmentVar()}/.gradle-home-tmp")) { artifactoryAuthenticated {
-                bat(("call gradlew.bat --no-daemon --stacktrace --build-cache " +
+                bat(("call gradlew.bat --stacktrace --build-cache " +
                         (gradleCredentials?.let { "-D$gradleUserProperty=%${it.usernameVariable.value}% -D$gradlePasswordProperty=%${it.passwordVariable.value}% " } ?: "") +
                         "$additionalBuildArgs $command").strDouble())
             } }

--- a/examples/src/generated/ci/gradleBuild.Jenkinsfile
+++ b/examples/src/generated/ci/gradleBuild.Jenkinsfile
@@ -1,41 +1,47 @@
 def Build() {
   withEnv([
-  	"GRADLE_USER_HOME=${env.WORKSPACE}/.gradle-home-tmp"
+  	"GRADLE_USER_HOME=${env.WORKSPACE}/.gradle-home-tmp",
+    "JENKINS_NODE_COOKIE=dontKillMe"
   ]) {
     sh (script: "./gradlew --stacktrace --build-cache ${""} build -DmyArg=myArgValue", returnStdout: false)
   }
 }
 def api_Test() {
   withEnv([
-  	"GRADLE_USER_HOME=${env.WORKSPACE}/.gradle-home-tmp"
+  	"GRADLE_USER_HOME=${env.WORKSPACE}/.gradle-home-tmp",
+    "JENKINS_NODE_COOKIE=dontKillMe"
   ]) {
     sh (script: "./gradlew --stacktrace --build-cache ${""} :api:systemTest -DmyArg=myArgValue", returnStdout: false)
   }
 }
 def ext_Test() {
   withEnv([
-  	"GRADLE_USER_HOME=${env.WORKSPACE}/.gradle-home-tmp"
+  	"GRADLE_USER_HOME=${env.WORKSPACE}/.gradle-home-tmp",
+    "JENKINS_NODE_COOKIE=dontKillMe"
   ]) {
     sh (script: "./gradlew --stacktrace --build-cache ${""} :ext:systemTest -DmyArg=myArgValue", returnStdout: false)
   }
 }
 def shared_Test() {
   withEnv([
-  	"GRADLE_USER_HOME=${env.WORKSPACE}/.gradle-home-tmp"
+  	"GRADLE_USER_HOME=${env.WORKSPACE}/.gradle-home-tmp",
+    "JENKINS_NODE_COOKIE=dontKillMe"
   ]) {
     sh (script: "./gradlew --stacktrace --build-cache ${""} :shared:systemTest -DmyArg=myArgValue", returnStdout: false)
   }
 }
 def mod1_Test() {
   withEnv([
-  	"GRADLE_USER_HOME=${env.WORKSPACE}/.gradle-home-tmp"
+  	"GRADLE_USER_HOME=${env.WORKSPACE}/.gradle-home-tmp",
+    "JENKINS_NODE_COOKIE=dontKillMe"
   ]) {
     sh (script: "./gradlew --stacktrace --build-cache ${""} :mod1:systemTest -DmyArg=myArgValue", returnStdout: false)
   }
 }
 def Publish() {
   withEnv([
-  	"GRADLE_USER_HOME=${env.WORKSPACE}/.gradle-home-tmp"
+  	"GRADLE_USER_HOME=${env.WORKSPACE}/.gradle-home-tmp",
+    "JENKINS_NODE_COOKIE=dontKillMe"
   ]) {
     sh (script: "./gradlew --stacktrace --build-cache ${""} publish -DmyArg=myArgValue", returnStdout: false)
   }

--- a/examples/src/generated/ci/gradleBuild.Jenkinsfile
+++ b/examples/src/generated/ci/gradleBuild.Jenkinsfile
@@ -2,42 +2,42 @@ def Build() {
   withEnv([
   	"GRADLE_USER_HOME=${env.WORKSPACE}/.gradle-home-tmp"
   ]) {
-    sh (script: "./gradlew --no-daemon --stacktrace --build-cache ${""} build -DmyArg=myArgValue", returnStdout: false)
+    sh (script: "./gradlew --stacktrace --build-cache ${""} build -DmyArg=myArgValue", returnStdout: false)
   }
 }
 def api_Test() {
   withEnv([
   	"GRADLE_USER_HOME=${env.WORKSPACE}/.gradle-home-tmp"
   ]) {
-    sh (script: "./gradlew --no-daemon --stacktrace --build-cache ${""} :api:systemTest -DmyArg=myArgValue", returnStdout: false)
+    sh (script: "./gradlew --stacktrace --build-cache ${""} :api:systemTest -DmyArg=myArgValue", returnStdout: false)
   }
 }
 def ext_Test() {
   withEnv([
   	"GRADLE_USER_HOME=${env.WORKSPACE}/.gradle-home-tmp"
   ]) {
-    sh (script: "./gradlew --no-daemon --stacktrace --build-cache ${""} :ext:systemTest -DmyArg=myArgValue", returnStdout: false)
+    sh (script: "./gradlew --stacktrace --build-cache ${""} :ext:systemTest -DmyArg=myArgValue", returnStdout: false)
   }
 }
 def shared_Test() {
   withEnv([
   	"GRADLE_USER_HOME=${env.WORKSPACE}/.gradle-home-tmp"
   ]) {
-    sh (script: "./gradlew --no-daemon --stacktrace --build-cache ${""} :shared:systemTest -DmyArg=myArgValue", returnStdout: false)
+    sh (script: "./gradlew --stacktrace --build-cache ${""} :shared:systemTest -DmyArg=myArgValue", returnStdout: false)
   }
 }
 def mod1_Test() {
   withEnv([
   	"GRADLE_USER_HOME=${env.WORKSPACE}/.gradle-home-tmp"
   ]) {
-    sh (script: "./gradlew --no-daemon --stacktrace --build-cache ${""} :mod1:systemTest -DmyArg=myArgValue", returnStdout: false)
+    sh (script: "./gradlew --stacktrace --build-cache ${""} :mod1:systemTest -DmyArg=myArgValue", returnStdout: false)
   }
 }
 def Publish() {
   withEnv([
   	"GRADLE_USER_HOME=${env.WORKSPACE}/.gradle-home-tmp"
   ]) {
-    sh (script: "./gradlew --no-daemon --stacktrace --build-cache ${""} publish -DmyArg=myArgValue", returnStdout: false)
+    sh (script: "./gradlew --stacktrace --build-cache ${""} publish -DmyArg=myArgValue", returnStdout: false)
   }
 }
 pipeline {


### PR DESCRIPTION
This change updates our gradle command so that we don't always disable the daemon. Users are still able to disable if they so choose but this should be something they have control over. We previously did this because it was stated that all CI builds should disable the daemon but that seems to not be the case anymore from the gradle docs:

https://docs.gradle.org/current/userguide/gradle_daemon.html#sec:disabling_the_daemon

**Continuous integration
Since Gradle 3.0, we enable Daemon by default and recommend using it for both developers' machines and Continuous Integration servers. However, if you suspect that Daemon makes your CI builds unstable, you can disable it to use a fresh runtime for each build since the runtime is completely isolated from any previous builds.**