### PR TITLE
Add empty result warnings around `withVault`  because it fails silently

### DIFF
--- a/core/src/main/kotlin/com/code42/jenkins/pipelinekt/core/secrets/Secrets.kt
+++ b/core/src/main/kotlin/com/code42/jenkins/pipelinekt/core/secrets/Secrets.kt
@@ -2,4 +2,5 @@ package com.code42.jenkins.pipelinekt.core.secrets
 
 interface Secrets {
     fun toGroovy(): String
+    fun getEnvironmentVariableNames(): List<String>
 }

--- a/core/src/main/kotlin/com/code42/jenkins/pipelinekt/core/secrets/VaultSecrets.kt
+++ b/core/src/main/kotlin/com/code42/jenkins/pipelinekt/core/secrets/VaultSecrets.kt
@@ -25,4 +25,8 @@ data class VaultSecrets(
         builder.append("  ]]]")
         return builder.toString()
     }
+
+    override fun getEnvironmentVariableNames(): List<String> {
+        return secrets.map { it.envVar }
+    }
 }

--- a/dsl/src/main/kotlin/com/code42/jenkins/pipelinekt/dsl/option/OptionsDsl.kt
+++ b/dsl/src/main/kotlin/com/code42/jenkins/pipelinekt/dsl/option/OptionsDsl.kt
@@ -9,6 +9,7 @@ import com.code42.jenkins.pipelinekt.core.vars.ext.strDouble
 import com.code42.jenkins.pipelinekt.dsl.DslContext
 import com.code42.jenkins.pipelinekt.internal.option.AnsiColor
 import com.code42.jenkins.pipelinekt.internal.option.DisableConcurrentBuilds
+import com.code42.jenkins.pipelinekt.internal.option.DisableConcurrentBuildsWithAbortPrevious
 import com.code42.jenkins.pipelinekt.internal.option.LogRotator
 import com.code42.jenkins.pipelinekt.internal.option.Retry
 import com.code42.jenkins.pipelinekt.internal.option.SkipDefaultCheckout
@@ -25,6 +26,10 @@ fun DslContext<Option>.buildDiscarder(buildDiscarder: BuildDiscarder) {
 
 fun DslContext<Option>.disableConcurrentBuilds() {
     add(DisableConcurrentBuilds)
+}
+
+fun DslContext<Option>.disableConcurrentBuildsWithAbortPrevious() {
+    add(DisableConcurrentBuildsWithAbortPrevious)
 }
 
 fun DslContext<Option>.ansiColor(colorMapName: String) {

--- a/internal/src/main/kotlin/com/code42/jenkins/pipelinekt/internal/option/DisableConcurrentBuildsWithAbortPrevious.kt
+++ b/internal/src/main/kotlin/com/code42/jenkins/pipelinekt/internal/option/DisableConcurrentBuildsWithAbortPrevious.kt
@@ -1,0 +1,10 @@
+package com.code42.jenkins.pipelinekt.internal.option
+
+import com.code42.jenkins.pipelinekt.core.Option
+import com.code42.jenkins.pipelinekt.core.writer.GroovyWriter
+
+object DisableConcurrentBuildsWithAbortPrevious : Option {
+    override fun toGroovy(writer: GroovyWriter) {
+        writer.writeln("disableConcurrentBuilds(abortPrevious: true)")
+    }
+}

--- a/internal/src/main/kotlin/com/code42/jenkins/pipelinekt/internal/step/declarative/WithVault.kt
+++ b/internal/src/main/kotlin/com/code42/jenkins/pipelinekt/internal/step/declarative/WithVault.kt
@@ -4,6 +4,7 @@ import com.code42.jenkins.pipelinekt.core.secrets.Secrets
 import com.code42.jenkins.pipelinekt.core.step.DeclarativeStep
 import com.code42.jenkins.pipelinekt.core.step.NestedStep
 import com.code42.jenkins.pipelinekt.core.step.Step
+import com.code42.jenkins.pipelinekt.core.vars.ext.strDouble
 import com.code42.jenkins.pipelinekt.core.writer.GroovyWriter
 
 /**
@@ -14,6 +15,18 @@ import com.code42.jenkins.pipelinekt.core.writer.GroovyWriter
  */
 data class WithVault(val secrets: Secrets, override val steps: Step) : DeclarativeStep, NestedStep {
     override fun toGroovy(writer: GroovyWriter) {
-        writer.closure(listOf("withVault([") + secrets.toGroovy() + "])", steps::toGroovy)
+
+        // The version of the Vault plugin we are using still has this issue, trying to access a secret that doesn't exist will fail silently.
+        // https://github.com/jenkinsci/hashicorp-vault-plugin/pull/257
+
+        var stepsPrefixedWithVaultEmptyResultWarnings = steps
+        secrets.getEnvironmentVariableNames().reversed().forEach {
+            val errorMessage = "WARNING: environment variable '$it' was not set, or was empty. Getting secrets from vault may have failed. ";
+            stepsPrefixedWithVaultEmptyResultWarnings = stepsPrefixedWithVaultEmptyResultWarnings.precededBy(
+                    Sh(script = "if [ ! \\\"\$$it\\\" ]; then echo \\\"$errorMessage\\\"; fi".strDouble())
+            )
+        }
+
+        writer.closure(listOf("withVault([") + secrets.toGroovy() + "])", stepsPrefixedWithVaultEmptyResultWarnings::toGroovy)
     }
 }

--- a/internal/src/test/kotlin/com/code42/jenkins/pipelinekt/internal/step/declarative/WithVaultTest.kt
+++ b/internal/src/test/kotlin/com/code42/jenkins/pipelinekt/internal/step/declarative/WithVaultTest.kt
@@ -15,6 +15,7 @@ class WithVaultTest : GroovyScriptTest() {
                 "    [envVar: 'ENV_VAR', vaultKey: 'VAULT_KEY']\n" +
                 "  ]]]\n" +
                 "]) {\n" +
+                "${indentStr}sh (script: \"if [ ! \\\"\$ENV_VAR\\\" ]; then echo \\\"WARNING: environment variable 'ENV_VAR' was not set, or was empty. Getting secrets from vault may have failed. \\\"; fi\", returnStdout: false)\n" +
                 "${indentStr}sh (script: \"echo testing...\", returnStdout: false)\n" +
                 "}\n"
         val secrets1 = VaultSecrets(
@@ -36,6 +37,8 @@ class WithVaultTest : GroovyScriptTest() {
                 "    [envVar: 'ENV_VAR2', vaultKey: 'VAULT_KEY2']\n" +
                 "  ]]]\n" +
                 "]) {\n" +
+                "${indentStr}sh (script: \"if [ ! \\\"\$ENV_VAR1\\\" ]; then echo \\\"WARNING: environment variable 'ENV_VAR1' was not set, or was empty. Getting secrets from vault may have failed. \\\"; fi\", returnStdout: false)\n" +
+                "${indentStr}sh (script: \"if [ ! \\\"\$ENV_VAR2\\\" ]; then echo \\\"WARNING: environment variable 'ENV_VAR2' was not set, or was empty. Getting secrets from vault may have failed. \\\"; fi\", returnStdout: false)\n" +
                 "${indentStr}sh (script: \"echo testing...\", returnStdout: false)\n" +
                 "}\n"
         val secrets1 = VaultSecrets(


### PR DESCRIPTION
see: https://github.com/jenkinsci/hashicorp-vault-plugin/pull/257