### PR TITLE
Add TryCatchDsl based on `if` implementation from BooleanStatementDsl

### DIFF
--- a/dsl/src/main/kotlin/com/code42/jenkins/pipelinekt/dsl/step/scripted/TryCatchDsl.kt
+++ b/dsl/src/main/kotlin/com/code42/jenkins/pipelinekt/dsl/step/scripted/TryCatchDsl.kt
@@ -1,0 +1,28 @@
+package com.code42.jenkins.pipelinekt.dsl.step.scripted
+
+import com.code42.jenkins.pipelinekt.core.step.Step
+import com.code42.jenkins.pipelinekt.core.writer.ext.toStep
+import com.code42.jenkins.pipelinekt.dsl.DslContext
+import com.code42.jenkins.pipelinekt.internal.step.scripted.Try
+
+@Suppress("UnusedPrivateMember")
+fun DslContext<Step>.`try`(
+        trySteps: DslContext<Step>.() -> Unit,
+        `catch`: (DslContext<Step>.() -> Unit)?
+) {
+    tryCatch(trySteps, `catch`)
+}
+
+fun DslContext<Step>.tryCatch(
+        tryStep: DslContext<Step>.() -> Unit,
+        catchStep: (DslContext<Step>.() -> Unit)?
+) {
+    val trySteps = DslContext.into(tryStep).toStep()
+    if(catchStep != null) {
+        val catchSteps = DslContext.into(catchStep).toStep()
+        add(Try(trySteps, catchSteps))
+    } else {
+        add(Try(trySteps, null))
+    }
+}
+

--- a/internal/src/main/kotlin/com/code42/jenkins/pipelinekt/internal/step/scripted/If.kt
+++ b/internal/src/main/kotlin/com/code42/jenkins/pipelinekt/internal/step/scripted/If.kt
@@ -12,6 +12,8 @@ data class If(
     val ifTrue: Step,
     val otherwise: Step? = null
 ) : ScriptedStep, NestedStep {
+
+    // I suspect that `steps` is only used by `isEmpty()`, that's why ifTrue and otherwise bodies are concatenated
     override val steps: Step
         get() = ifTrue.andThen(otherwise ?: Void)
 

--- a/internal/src/main/kotlin/com/code42/jenkins/pipelinekt/internal/step/scripted/Try.kt
+++ b/internal/src/main/kotlin/com/code42/jenkins/pipelinekt/internal/step/scripted/Try.kt
@@ -1,0 +1,22 @@
+package com.code42.jenkins.pipelinekt.internal.step.scripted
+
+import com.code42.jenkins.pipelinekt.core.step.NestedStep
+import com.code42.jenkins.pipelinekt.core.step.ScriptedStep
+import com.code42.jenkins.pipelinekt.core.step.Step
+import com.code42.jenkins.pipelinekt.core.step.Void
+import com.code42.jenkins.pipelinekt.core.writer.GroovyWriter
+
+data class Try(
+    val tryStep: Step,
+    val catchStep: Step? = null
+) : ScriptedStep, NestedStep {
+
+    // I suspect that `steps` is only used by `isEmpty()`, that's why tryStep and catchStep bodies are concatenated
+    override val steps: Step
+        get() = tryStep.andThen(catchStep ?: Void)
+
+    override fun scriptedGroovy(writer: GroovyWriter) {
+        writer.closure("try", tryStep::toGroovy)
+        catchStep?.let { writer.closure("catch(exc)", it::toGroovy) }
+    }
+}


### PR DESCRIPTION
I want to do this: 

```
        try {
           unstash 'something'
        } catch (e) {
           print "Unstash failed, now doing something else...."
        }
```


> [**How to avoid failure on missing stash during unstash in Jenkinsfile in the first run?**](
https://stackoverflow.com/a/58963672)